### PR TITLE
Rename the project from "early_windows" to "halfway"

### DIFF
--- a/jolly-jellyfish/src/django_meta/settings.py
+++ b/jolly-jellyfish/src/django_meta/settings.py
@@ -1,4 +1,4 @@
-"""Django settings for early_windows project."""
+"""Django settings for halfway project."""
 import random
 import string
 import os

--- a/jolly-jellyfish/src/django_meta/urls.py
+++ b/jolly-jellyfish/src/django_meta/urls.py
@@ -1,4 +1,4 @@
-"""early_windows URL Configuration"""
+"""halfway URL Configuration"""
 from django.contrib import admin
 from django.urls import path
 

--- a/jolly-jellyfish/src/django_meta/wsgi.py
+++ b/jolly-jellyfish/src/django_meta/wsgi.py
@@ -1,5 +1,5 @@
 """
-WSGI config for early_windows project.
+WSGI config for halfway project.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 


### PR DESCRIPTION
We accidentally left these little marks I guess? I updated them nonetheless.